### PR TITLE
parameterize reconstruct command's when attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The orb's `reconstruct` command and job both take three optional parameters:
 | `circle-token` | `env_var_name` | `CIRCLE_TOKEN` | Name of environment variable storing your CircleCI API token |
 | `project-path` | `string` | `~/project` | Absolute path to your project's base directory, for running `git` commands |
 | `debug` | boolean | `false` | Additional debugging output for folks developing the orb |
+| `when` | `enum` | `always` | Specify when this command will run ([`always`, `on_fail`, `on_success`]) |
 
 Its job also takes an optional fourth paramater, which allows users to run the job in a [smaller container](https://circleci.com/docs/2.0/configuration-reference/#resource_class) to conserve resources:
 

--- a/src/commands/reconstruct.yml
+++ b/src/commands/reconstruct.yml
@@ -6,32 +6,27 @@ description: >
 
 parameters:
   circle-token:
-    description: >
-      Your CircleCI API token, defaults to $CIRCLE_TOKEN
     type: env_var_name
     default: CIRCLE_TOKEN
+    description: Your CircleCI API token, defaults to $CIRCLE_TOKEN
 
   project-path:
+    type: string
+    default: ~/project
     description: >
       Absolute path to your project's base directory, necessary for
       running git commands
-    type: string
-    default: ~/project
 
   debug:
-    description: >
-      Additional debugging output for folks developing the orb
     type: boolean
     default: false
+    description: Additional debugging output for folks developing the orb
 
   when:
-    description: When this command should run
     type: enum
+    enum: [always, on_success, on_fail]
     default: always
-    enum:
-      - always
-      - on_success
-      - on_fail
+    description: When should this command run?
 
 steps:
   - orb-tools/check-env-var-param:

--- a/src/commands/reconstruct.yml
+++ b/src/commands/reconstruct.yml
@@ -24,6 +24,15 @@ parameters:
     type: boolean
     default: false
 
+  when:
+    description: When this command should run
+    type: enum
+    default: always
+    enum:
+      - always
+      - on_success
+      - on_fail
+
 steps:
   - orb-tools/check-env-var-param:
       param: <<parameters.circle-token>>
@@ -34,7 +43,7 @@ steps:
 
   - run:
       name: Reconstruct CIRCLE_COMPARE_URL
-      when: always
+      when: <<parameters.when>>
       command: |
         ## VARS
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
resolves #31 
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Added some configurability to allow users to override the `reconstruct` command's `when` attribute.  I left the previously hard-coded value (`always`) as the default, to avoid any breaking changes.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
