### PR TITLE
Add `shell-options` parameter to `use`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The `use` command also takes three optional parameters and one that is technical
 | `attach-workspace` | `boolean` | `false` | Attach a workspace for this command to use? Useful when this orb's `reconstruct` job is called upstream in a given workflow |
 | `workspace-root` | `string` | "." | Workspace root path (either an absolute path or a path relative to the working directory), defaults to "." (the working directory) |
 | `custom-logic` | `string` | echo "What should COMMIT_RANGE ($COMMIT_RANGE) be used for?" | What should be done with the commit information created by the `reconstruct` command/job? [See examples in the orb registry](https://circleci.com/orbs/registry/orb/iynere/compare-url) (or [below](#examples)) |
+| `shell-options` | `string` | /bin/bash -eo pipefail | The shell options for `custom-loginc`. Default is `/bin/bash -eo pipefail`. See the document for [using shell scripts](https://circleci.com/docs/2.0/using-shell-scripts/). |
 
 Refer to CircleCI's [Reusing Config](https://circleci.com/docs/2.0/reusing-config/#using-the-parameters-declaration) documentation for additional information about parameters.
 
@@ -116,6 +117,7 @@ jobs:
 
       - compare-url/use:
           step-name: Publish modified orbs
+          shell-options: /bin/sh -ueo pipefail
           custom-logic: |
             for ORB in folder-containing-orb-subdirs/*/; do
 

--- a/src/commands/use.yml
+++ b/src/commands/use.yml
@@ -35,6 +35,13 @@ parameters:
       `reconstruct` command/job? For an example, see the following:
       https://circleci.com/orbs/registry/orb/iynere/compare-url#usage-simple-monorepo-flow-using-command
 
+  shell-options:
+    type: string
+    default: /bin/bash -eo pipefail
+    description: >
+      The shell options for `custom-loginc`. Default is `/bin/bash -eo pipefail`.
+      See the following: https://circleci.com/docs/2.0/using-shell-scripts/
+
 steps:
   - when:
       condition: <<parameters.attach-workspace>>
@@ -44,6 +51,7 @@ steps:
 
   - run:
       name: <<parameters.step-name>>
+      shell: <<parameters.shell-options>>
       command: |
         # save value stored in file to a local env var
         CIRCLE_COMPARE_URL=$(cat CIRCLE_COMPARE_URL.txt)

--- a/src/examples/simple-monorepo-flow-using-command.yml
+++ b/src/examples/simple-monorepo-flow-using-command.yml
@@ -22,6 +22,7 @@ usage:
 
         - compare-url/use:
             step-name: Publish modified orbs
+            shell-options: /bin/sh -ueo pipefail
             custom-logic: |
               for ORB in folder-containing-orb-subdirs/*/; do
 


### PR DESCRIPTION
Hi, I added `shell-options` parameter. please review 🙏 

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Useful to be able to select shell options when running custom-logic.

### Description

I added `shell-options` parameter to `use`. Default is `/bin/bash -eo pipefail`.