### PR TITLE
fix new branch ancestor handling flow

### DIFF
--- a/src/commands/reconstruct.yml
+++ b/src/commands/reconstruct.yml
@@ -163,7 +163,8 @@ steps:
             cd <<parameters.project-path>>
 
             # check if commit from JOB_NUM is an ancestor of $CIRCLE_SHA1
-            git merge-base --is-ancestor $COMMIT_FROM_JOB_NUM $CIRCLE_SHA1 || { RETURN_CODE=$?; }
+            git merge-base --is-ancestor $COMMIT_FROM_JOB_NUM $CIRCLE_SHA1
+            RETURN_CODE=$?
 
             if [[ $RETURN_CODE == 1 ]]; then
               echo "----------------------------------------------------------------------------------------------------"
@@ -171,7 +172,7 @@ steps:
               echo "----------------------------------------------------------------------------------------------------"
               JOB_NUM=$(( $JOB_NUM - 1 ))
               continue
-            elif [[ $RETURN_CODE == "" ]]; then
+            elif [[ $RETURN_CODE == 0 ]]; then
               echo "----------------------------------------------------------------------------------------------------"
               echo "commit $COMMIT_FROM_JOB_NUM from job $JOB_NUM is an ancestor of the current commit"
               echo "----------------------------------------------------------------------------------------------------"


### PR DESCRIPTION
The RETURN_CODE was not properly set in cases where the `git merge-base --is-ancestor` call returned successfully after a previous unsuccessful result.

I tried testing the fix by manually inserting the orb command's content directly in our CircleCI config. It seemed to work for the way I was testing, and the fix intuitively seems like it should resolve the bug. It's admittedly not quite as thoroughly tested as it could be.

### Checklist

(Note none of these apply as this is a bug fix)

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

This should fix #25 where a bug in the new branch flow is not properly finding its ancestor.

### Description

Fix handling of return code such that the job iteration logic properly identifies the ancestor commit in a new branch flow.