### PR TITLE
fix bug of commit is not an ancestor of the current commit

### DIFF
--- a/src/commands/reconstruct.yml
+++ b/src/commands/reconstruct.yml
@@ -170,6 +170,7 @@ steps:
               echo "commit $COMMIT_FROM_JOB_NUM from job $JOB_NUM is not an ancestor of the current commit"
               echo "----------------------------------------------------------------------------------------------------"
               JOB_NUM=$(( $JOB_NUM - 1 ))
+              unset RETURN_CODE
               continue
             elif [[ $RETURN_CODE == "" ]]; then
               echo "----------------------------------------------------------------------------------------------------"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Fix the bug of commit is not an ancestor of the current commit

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

if we push a new branch and the commit id of previous job is not an ancestor of the current commit then `RETURN_CODE ` is 1,  when the script really find an ancestor of the current commit
`git merge-base --is-ancestor $COMMIT_FROM_JOB_NUM $CIRCLE_SHA1 || { RETURN_CODE=$?; }`, the git command return `0`, but `{ RETURN_CODE=$?; }` will not executed due to `||`