### PR TITLE
Commits discarded by history rewriting should be ignored and branch considered as new

### DIFF
--- a/src/commands/reconstruct.yml
+++ b/src/commands/reconstruct.yml
@@ -177,6 +177,12 @@ steps:
               echo "----------------------------------------------------------------------------------------------------"
               FOUND_BASE_COMPARE_COMMIT=true
               break
+            elif [[ $RETURN_CODE == 128 ]]; then
+              echo "----------------------------------------------------------------------------------------------------"
+              echo "commit $COMMIT_FROM_JOB_NUM from job $JOB_NUM no longer exists"
+              echo "----------------------------------------------------------------------------------------------------"
+              JOB_NUM=$(( $JOB_NUM - 1 ))
+              continue
             else
               echo "unknown return code $RETURN_CODE from git merge-base with base commit $COMMIT_FROM_JOB_NUM, from job $JOB_NUM"
               exit 1
@@ -195,11 +201,27 @@ steps:
               # (we've already ruled out that this is a brand-new branch)
               $(grep "\"branch\" : \"$CIRCLE_BRANCH\"" JOB_OUTPUT) ]]; then
 
-              echo "----------------------------------------------------------------------------------------------------"
-              echo "success! job $JOB_NUM was neither part of the current workflow, part of a rerun workflow, a retry of a previous job, nor from a different branch"
-              echo "----------------------------------------------------------------------------------------------------"
+              COMMIT_FROM_JOB_NUM=$(extract_commit_from_job $VCS_TYPE $JOB_NUM)
 
-              FOUND_BASE_COMPARE_COMMIT=true
+              # check if commit from JOB_NUM is still an ancestor of $CIRCLE_SHA1
+              git merge-base --is-ancestor $COMMIT_FROM_JOB_NUM $CIRCLE_SHA1; RETURN_CODE=$?
+
+              if [[ $RETURN_CODE == 0 ]]; then
+
+                echo "----------------------------------------------------------------------------------------------------"
+                echo "success! job $JOB_NUM was neither part of the current workflow, part of a rerun workflow, a retry of a previous job, nor from a different branch"
+                echo "----------------------------------------------------------------------------------------------------"
+
+                FOUND_BASE_COMPARE_COMMIT=true
+                break
+              else
+                echo "----------------------------------------------------------------------------------------------------"
+                echo "commit $COMMIT_FROM_JOB_NUM from job $JOB_NUM is attached to the same branch as the current commit, but history has been rewritten since. Might as well consider the current branch as a new one."
+                echo "----------------------------------------------------------------------------------------------------"
+                JOB_NUM=$(( $JOB_NUM - 1 ))
+                BRANCH_IS_NEW=true
+                continue
+              fi
             else
               echo "----------------------------------------------------------------------------------------------------"
               echo "job $JOB_NUM was part of the current workflow, part of a rerun workflow, a retry of a previous job, or from a different branch"


### PR DESCRIPTION
### Checklist

- [x] <del>All new jobs, commands, executors, parameters have descriptions</del> (not relevant here)
- [x] <del>Examples have been added for any significant new features</del> (not relevant here)
- [x] <del>README has been updated, if necessary</del> (not relevant here)

### Motivation, issues

Behaviours in case of branch being rebased or when the job previous runs included entries on commit which had been discarded (following a rebase or a squash) was... not working.

This is basically what's being described in the 3 below issues:
- https://github.com/iynere/compare-url/issues/41
- https://github.com/iynere/compare-url/issues/40
- https://github.com/iynere/compare-url/issues/25

### Description

Basically there was an issue which occurred with history rewrites (which can happen often in cases where people tend to squash their commits and / or rebase at head before merging, which is my case).

The idea is to basically say that:
* If a commit from a previous build was lost it should be ignored
* If a branch's previous job was on a no longer existing commit it should be considered as a new branch
